### PR TITLE
Allow `TypedArray`s in assert

### DIFF
--- a/utf15.js
+++ b/utf15.js
@@ -206,7 +206,7 @@ const Impl = (()=>{
         /// @param arg -- single value or array of values to be encoded
         /// @returns encoded string
         encode(arg) {
-            assert(+Array.isArray(arg) ^ !this.array, TypeCodecError,
+            assert((+Array.isArray(arg) | +(!!(arg).BYTES_PER_ELEMENT)) ^ !this.array, TypeCodecError,
                 'Incompatible codec (array <=> single value), arg =', arg);
             
             let res = '';


### PR DESCRIPTION
the assert at the beginning of `Codec.encode` failed when a `TypedArray`
was passed in, as opposed to an `Array`. This uses duck typing of
`.BYTES_PER_ELEMENT` which applies to any TypedArray (`Uint8Array`,
`Float64Array`, etc) and allows the `TypedArray`s to be passed in.